### PR TITLE
[fix issue #4] Stores original referrer in cookie on redirect

### DIFF
--- a/demo/src/public/experiment-page1.js
+++ b/demo/src/public/experiment-page1.js
@@ -3,6 +3,7 @@
 
     var eddie = new Mozilla.TrafficCop({
         id: 'experiment-page-1',
+        cookieExpires: 0, // session length cookie
         variations: {
             'v=1': 50,
             'v=2': 20,

--- a/demo/src/public/experiment-page2.js
+++ b/demo/src/public/experiment-page2.js
@@ -3,6 +3,7 @@
 
     var lou = new Mozilla.TrafficCop({
         id: 'experiment-page-2',
+        storeReferrerCookie: false, // don't store original referrer on redirect
         variations: {
             'v=a': 20,
             'v=b': 40

--- a/documentation.md
+++ b/documentation.md
@@ -67,7 +67,11 @@ In the above example, the string *experiment-new-headline* will be used as the c
 
 The test will have 3 variations, each targeting 25% of users.
 
-There is also an optional configuration value to specify how long the cookie associated with a visitor for an individual experiment will last: `cookieExpires`. This value must be a `Number` and represents the number of hours the cookie will last. If omitted, the cookie will last for 24 hours. A value of 0 will result in a session-length cookie.
+### Optional Configuration
+
+1. Customizing how long a user sees the same variation
+
+To specify how long the cookie associated with a visitor for an individual experiment will last, specify a `cookieExpires` value in the configuration. This value must be a `Number` and represents the number of hours the cookie will last. If omitted, the cookie will last for 24 hours. A value of 0 will result in a session-length cookie.
 
 An implementation with `cookieExpires` set might look like the following:
 
@@ -83,6 +87,29 @@ var lou = new Mozilla.TrafficCop({
 });
 
 lou.init();
+```
+
+2. Maintaining referral sources
+
+One obstacle with client-side redirects is that the original referrer gets lost, which makes it difficult to know where your traffic is coming from. To remedy this, Traffic Cop by default sets a cookie just prior to redirecting the visitor that holds the original value of `document.referer`. This cookie is named *mozilla-traffic-cop-original-referrer* and contains the value of `document.referer`, or *direct* if `document.referer` is empty.
+
+If you don't need this cookie, simply pass `setReferrerCookie: false` in your configuration. By default, this cookie will be set.
+
+This cookie uses the same `cookieExpires` value as described above.
+
+**Note** Traffic Cop does nothing with this cookie. If required for your implementation, you'll need to check for this cookie on your variation pages and send it on to your analytics platform (or wherever you might need it).
+
+At Mozilla, we use Google Tag Manager, and send this cookie information via a `dataLayer` push prior to the GTM script being loaded.
+
+**If you are using this cookie, we recommend explicitly removing it after use!**
+
+```javascript
+// ...
+// code to read the referrer cookie and send it to analytics
+// ...
+
+// now clear the cookie so we don't accidentally read it again
+Mozilla.Cookies.removeItem('mozilla-traffic-cop-original-referrer')
 ```
 
 

--- a/src/mozilla-traffic-cop.js
+++ b/src/mozilla-traffic-cop.js
@@ -58,6 +58,9 @@ Mozilla.TrafficCop = function(config) {
     // store experiment cookie expiry (defaults to 24 hours)
     this.cookieExpires = (config.cookieExpires !== undefined) ? config.cookieExpires : 24;
 
+    // store pref to store referrer cookie on redirect (default to true)
+    this.storeReferrerCookie = (config.storeReferrerCookie === false) ? false : true;
+
     this.redirectVariation = null;
 
     // calculate and store total percentage of variations
@@ -71,6 +74,7 @@ Mozilla.TrafficCop = function(config) {
 };
 
 Mozilla.TrafficCop.noVariationCookieValue = 'novariation';
+Mozilla.TrafficCop.referrerCookieName = 'mozilla-traffic-cop-original-referrer';
 
 /*
  * Initialize the traffic cop. Validates variations, ensures user is not
@@ -97,16 +101,30 @@ Mozilla.TrafficCop.prototype.init = function() {
             // roll the dice to see if user should be send to a variation
             redirectUrl = this.generateRedirectUrl();
 
-            if (redirectUrl) {
-                // if we get a variation, send the user and store a cookie
-                if (redirectUrl !== Mozilla.TrafficCop.noVariationCookieValue) {
-                    Mozilla.Cookies.setItem(this.id, this.redirectVariation, this.cookieExpiresDate());
-                    window.location.href = redirectUrl;
+            // if we get a variation, send the user and store a cookie
+            if (redirectUrl && redirectUrl !== Mozilla.TrafficCop.noVariationCookieValue) {
+                // Store the original referrer for use after redirect takes place so analytics can
+                // keep track of where visitors are coming from.
+
+                // Traffic Cop does nothing with this referrer - it's up to the implementing site to
+                // send it on to an analytics platform (or whatever).
+                if (this.storeReferrerCookie) {
+                    Mozilla.TrafficCop.setReferrerCookie(this.cookieExpiresDate());
+                // a previous experiment may have set the cookie, so explicitly remove it here
+                } else {
+                    Mozilla.TrafficCop.clearReferrerCookie();
                 }
+
+                Mozilla.Cookies.setItem(this.id, this.redirectVariation, this.cookieExpiresDate());
+
+                Mozilla.TrafficCop.performRedirect(redirectUrl);
             } else {
                 // if no variation, set a cookie so user isn't re-entered into
                 // the dice roll on next page load
                 Mozilla.Cookies.setItem(this.id, Mozilla.TrafficCop.noVariationCookieValue, this.cookieExpiresDate());
+
+                // same as above - referrer cookie could be set from previous experiment, so best to clear
+                Mozilla.TrafficCop.clearReferrerCookie();
             }
         }
     }
@@ -233,4 +251,20 @@ Mozilla.TrafficCop.prototype.generateRedirectUrl = function(url) {
     }
 
     return redirect;
+};
+
+Mozilla.TrafficCop.performRedirect = function(redirectURL) {
+    window.location.href = redirectURL;
+};
+
+Mozilla.TrafficCop.setReferrerCookie = function(expirationDate, referrer) {
+    if (referrer !== false) {
+        referrer = referrer || document.referrer;
+    }
+
+    Mozilla.Cookies.setItem(Mozilla.TrafficCop.referrerCookieName, referrer || 'direct', expirationDate);
+};
+
+Mozilla.TrafficCop.clearReferrerCookie = function() {
+    Mozilla.Cookies.removeItem(Mozilla.TrafficCop.referrerCookieName);
 };


### PR DESCRIPTION
Adds functionality to store the original `document.referer` in a cookie prior to any redirects taking place.

Adds tests, too.

For reference: https://bugzilla.mozilla.org/show_bug.cgi?id=1364236